### PR TITLE
Optimize Dockerfile to leverage layer caching for dependency installation

### DIFF
--- a/MasterProject/Dockerfile
+++ b/MasterProject/Dockerfile
@@ -2,20 +2,23 @@ FROM python:3.10.13-slim
 
 ENV PYTHONBUFFERED=1
 
-COPY . /django
 WORKDIR /django
+
+COPY requirements.txt requirements.txt
 
 RUN python3 -m venv /opt/venv
 
 RUN /opt/venv/bin/pip install --upgrade pip && \
-    /opt/venv/bin/pip install -r requirements.txt && \
-    apt-get update && \
-    apt-get install -y tesseract-ocr
+    /opt/venv/bin/pip install -r requirements.txt
 
-RUN /opt/venv/bin/python manage.py collectstatic --noinput
+COPY . /django
+
+RUN apt-get update && \
+    apt-get install -y tesseract-ocr && \
+    /opt/venv/bin/python manage.py collectstatic --noinput
 
 RUN chmod +x docker-entrypoint.sh
 
-CMD ["/django/docker-entrypoint.sh"]
-
 EXPOSE 8000
+
+CMD ["/django/docker-entrypoint.sh"]


### PR DESCRIPTION
Fixes #44 
### PR Description
#### Debugged Issue: 
When you create a virtual environment (python3 -m venv /opt/venv) and install dependencies (pip install -r requirements.txt) within it, Docker considers changes to the entire virtual environment directory as a cache-invalidation event.

This PR optimizes the Dockerfile to improve build performance by leveraging layer caching for dependency installation from `requirements.txt`. Currently, the Docker build process downloads and installs dependencies from `requirements.txt` every time, even when the file hasn't changed. This leads to longer build times and unnecessary network usage.

The optimization involves separating the installation of Python dependencies from the rest of the application code in the Dockerfile. By copying `requirements.txt` separately and installing dependencies in a separate `RUN` step, Docker can cache the installed dependencies separately from the rest of the application code. This allows Docker to reuse the cached layer containing the installed dependencies if `requirements.txt` hasn't changed between builds, resulting in faster build times.

#### This PR implements the following changes:
- Copies `requirements.txt` separately into the Docker image
- Installs dependencies in a separate `RUN` step
- Copies the rest of the application code after installing dependencies

With these changes, Docker can more effectively leverage layer caching, reducing the need to reinstall dependencies during the build process and improving overall build performance.

This PR addresses the issue reported in #[Issue_Number].

### Testing
- [x] Tested locally to ensure that dependencies are not reinstalled unnecessarily during the Docker build process
- [x] Verified that Docker build times are improved compared to before the optimization