### PR TITLE
Reuse Django Image for Celery Worker Service to Avoid Redundant Dependency Downloads

### DIFF
--- a/MasterProject/Dockerfile
+++ b/MasterProject/Dockerfile
@@ -2,20 +2,20 @@ FROM python:3.10.13-slim
 
 ENV PYTHONBUFFERED=1
 
-COPY /model/keras_model/xception_weights_tf_dim_ordering_tf_kernels_notop.h5 /root/.keras/models/
-
-COPY . /django
+COPY model/keras_model/xception_weights_tf_dim_ordering_tf_kernels_notop.h5 /root/.keras/models/
 
 WORKDIR /django
+
+COPY requirements.txt requirements.txt
+
+RUN pip install -r requirements.txt
 
 RUN apt-get update && \
     apt-get install -y tesseract-ocr
 
-RUN pip install --upgrade pip && \
-    pip install -r requirements.txt
+COPY . /django
 
 RUN python manage.py collectstatic --noinput
-
 
 RUN chmod +x docker-entrypoint.sh
 

--- a/MasterProject/docker-compose.yml
+++ b/MasterProject/docker-compose.yml
@@ -32,10 +32,7 @@ services:
     depends_on:
       - app
       - redis
-    build:
-      context: .
-      dockerfile: Dockerfile
-    image: snapspeak-celery:v1
+    image: snapspeak-django:v1
     env_file:
       - .env
     container_name: snapspeak_celery_worker
@@ -43,3 +40,4 @@ services:
 
 volumes:
   mongo_data:
+  dependencies:

--- a/MasterProject/docker-compose.yml
+++ b/MasterProject/docker-compose.yml
@@ -40,4 +40,3 @@ services:
 
 volumes:
   mongo_data:
-  dependencies:


### PR DESCRIPTION
**Pull Request Description:**

This pull request addresses the issue of redundant dependency downloads in the Django app and Celery worker services by reusing the Docker image built for the Django app service (`snapspeak-django:v1`) for the Celery worker service as well.

**Approach:**

Previously, both the Django app and Celery worker services were separately building their Docker images, resulting in duplicated downloads of dependencies specified in the `requirements.txt` file. To mitigate this, I modified the `docker-compose.yml` configuration to utilize the same Docker image for both services.

**Changes Made:**

- Updated the `docker-compose.yml` file to remove the separate image specification for the Celery worker service.
- Instead, set the `image` property for the Celery worker service to `snapspeak-django:v1`, which is the Docker image built for the Django app service.
- This change ensures that the same set of dependencies downloaded for the Django app service is shared with the Celery worker service, eliminating redundant downloads and reducing build time.

**Testing:**

- Verified the changes locally by rebuilding the Docker images and observing that dependencies were not re-downloaded for the Celery worker service.
- Confirmed that both the Django app and Celery worker services function correctly with the shared Docker image.

**Related Issues:**

Fixes #51 

**Additional Notes:**

- This approach streamlines the Docker build process and improves efficiency by avoiding unnecessary downloads of dependencies.
- The change has been tested locally and is ready for review and integration into the main branch.
- When Docker builds an image, it caches each layer. If a layer changes, Docker invalidates all subsequent layers and rebuilds them. So, in the Dockerfile, you should place the parts that are least likely to change towards the top and the parts that are more likely to change towards the bottom.